### PR TITLE
Fix error reporting when database queries fail

### DIFF
--- a/src/xgp3.0.0/upload/application/core/Database.php
+++ b/src/xgp3.0.0/upload/application/core/Database.php
@@ -328,7 +328,7 @@ class Database
     {
         if (!$result) {
 
-            $output = "Database query failed: " . mysql_error();
+            $output = "Database query failed: " . $this->connection->error;
 
             // uncomment below line when you want to debug your last query
             $output .= " Last SQL Query: " . $this->last_query;


### PR DESCRIPTION
`mysql_error()` was in use, which doesn't really work since the driver being used is mysqli