### PR TITLE
Fix SYSTEM_ROOT redirect

### DIFF
--- a/src/upload/application/config/constants.php
+++ b/src/upload/application/config/constants.php
@@ -59,13 +59,13 @@ define(
 );
 
 // SYSTEM ROOT, IGNORING PUBLIC
-define('SYSTEM_ROOT', PROTOCOL . strtr(BASE_PATH, ['public' => '', 'public/' => '']));
+define('SYSTEM_ROOT', PROTOCOL . strtr(BASE_PATH, ['public' => '', 'public/' => '']) .'/');
 
 // GAME URL
 define('GAMEURL', PROTOCOL . $_SERVER['HTTP_HOST'] . '/');
 
 // ADMIN PATHS
-define('ADM_URL', PROTOCOL . strtr(BASE_PATH, ['public' => '', 'public/' => '']));
+define('ADM_URL', PROTOCOL . strtr(BASE_PATH, ['public' => '', 'public/' => '']) .'/');
 
 /**
  *


### PR DESCRIPTION
Fix broken redirect, as when installing for first time, the install URL is invalid.
```
> GET / HTTP/1.1
> Host: midominio.com
> User-Agent: curl/7.64.0
> Accept: */*
> 

* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
HTTP/1.1 302 Found
Date: Sat, 03 Oct 2020 16:26:39 GMT
Server: Apache/2.4.29 (Ubuntu)
location: https://midominio.cominstall/
Content-Length: 0
Content-Type: text/html; charset=UTF-8
```