### PR TITLE
Update Dockerfile to add only XGProyect folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,6 @@ RUN a2enmod rewrite expires
 
 VOLUME /var/www/html
 
-COPY . /var/www/html
+COPY --chown=www-data:www-data ./src/upload /var/www/html
 
 CMD ["apache2-foreground"]


### PR DESCRIPTION
Relates to #427 
Force to use `www-data` owner user for the Docker Apache image, and copy only the `upload` folder.