### PR TITLE
Fix bug where destroyed ships and defense isn't reflected in points

### DIFF
--- a/src/upload/app/ThirdParty/battle_engine/core/BattleReport.php
+++ b/src/upload/app/ThirdParty/battle_engine/core/BattleReport.php
@@ -359,7 +359,7 @@ class BattleReport
         }
         return $lostShips;
     }
-    private function getPlayersLostShips(PlayerGroup $playersBefore, PlayerGroup $playersAfter)
+    public function getPlayersLostShips(PlayerGroup $playersBefore, PlayerGroup $playersAfter)
     {
         $playersBefore_clone = $playersBefore->cloneMe();
 

--- a/src/upload/app/libraries/missions/Expedition.php
+++ b/src/upload/app/libraries/missions/Expedition.php
@@ -136,10 +136,12 @@ class Expedition extends Missions
                 $fleet_row['fleet_end_stay']
             );
 
+            $this->Missions_Model->updateLostShipsAndDefensePoints($fleet_row['fleet_owner'], $current_fleet);
             parent::removeFleet($fleet_row['fleet_id']);
         } else {
             $this->all_destroyed = true;
             $new_ships = [];
+            $lost_ships = [];
 
             foreach ($current_fleet as $ship => $amount) {
                 if (floor($amount * $lost_amount) != 0) {
@@ -156,6 +158,7 @@ class Expedition extends Missions
                     $fleet_row['fleet_end_stay']
                 );
 
+                $this->Missions_Model->updateLostShipsAndDefensePoints($fleet_row['fleet_owner'], $lost_ships);
                 $this->Missions_Model->updateFleetArrayById([
                     'ships' => FleetsLib::setFleetShipsArray($new_ships),
                     'fleet_id' => $fleet_row['fleet_id'],
@@ -167,6 +170,7 @@ class Expedition extends Missions
                     $fleet_row['fleet_end_stay']
                 );
 
+                $this->Missions_Model->updateLostShipsAndDefensePoints($fleet_row['fleet_owner'], $current_fleet);
                 parent::removeFleet($fleet_row['fleet_id']);
             }
         }

--- a/src/upload/app/models/libraries/missions/missions.php
+++ b/src/upload/app/models/libraries/missions/missions.php
@@ -13,12 +13,41 @@ namespace App\models\libraries\missions;
 
 use App\core\Model;
 use App\libraries\FleetsLib;
+use App\libraries\Statistics_library;
 
 /**
  * Missions Class
  */
 class Missions extends Model
 {
+    /**
+     * updateLostShipsAndDefensePoints
+     *
+     * @param integer $player_id   Player id
+     * @param array   $lost  Array of players lost units
+     *
+     * @return void
+     */
+    public function updateLostShipsAndDefensePoints($player_id, $lost)
+    {
+      $shippoints = 0;
+      $defensepoints = 0;
+      foreach ($lost as $unit => $lostcount) {
+        if ($unit >= 401) {
+          $defensepoints += Statistics_library::calculatePoints($unit, 1) * $lostcount;
+        }
+        else {
+          $shippoints += Statistics_library::calculatePoints($unit, 1) * $lostcount;
+        }
+      }
+      $this->db->query(
+          "UPDATE " . USERS_STATISTICS . " AS us SET
+          us.`user_statistic_ships_points` = us.`user_statistic_ships_points` - '" . $shippoints . "' ,
+          us.`user_statistic_defenses_points` = us.`user_statistic_defenses_points` - '" . $defensepoints . "'
+          WHERE us.`user_statistic_user_id` = '" . $player_id . "'"
+      );
+    }
+
     /**
      * Delete a fleet by its ID
      *


### PR DESCRIPTION
Previously the Fleet- and Defense-points reflected the total built ships and defense, regardless of how much was destroyed.
This makes a player look considerably stronger than they are and exposes them through prematurely disabled noob-protection to higher-level players and hinders attacking equally strong players that haven't lost as much yet.

Fleet and Defense-points should therefore reflect the current fleet and defense, which this PR fixes.

I haven't implemented points for when finding ships in expeditions, this should also be added. I might add this later, but for now this isn't a problem on my personal server. 