### PR TITLE
Fix espionage probes return obsolete data

### DIFF
--- a/src/upload/app/ThirdParty/battle_engine/core/BattleReport.php
+++ b/src/upload/app/ThirdParty/battle_engine/core/BattleReport.php
@@ -359,7 +359,7 @@ class BattleReport
         }
         return $lostShips;
     }
-    private function getPlayersLostShips(PlayerGroup $playersBefore, PlayerGroup $playersAfter)
+    public function getPlayersLostShips(PlayerGroup $playersBefore, PlayerGroup $playersAfter)
     {
         $playersBefore_clone = $playersBefore->cloneMe();
 

--- a/src/upload/app/libraries/missions/Expedition.php
+++ b/src/upload/app/libraries/missions/Expedition.php
@@ -136,10 +136,12 @@ class Expedition extends Missions
                 $fleet_row['fleet_end_stay']
             );
 
+            $this->Missions_Model->updateLostShipsAndDefensePoints($fleet_row['fleet_owner'], $current_fleet);
             parent::removeFleet($fleet_row['fleet_id']);
         } else {
             $this->all_destroyed = true;
             $new_ships = [];
+            $lost_ships = [];
 
             foreach ($current_fleet as $ship => $amount) {
                 if (floor($amount * $lost_amount) != 0) {
@@ -156,6 +158,7 @@ class Expedition extends Missions
                     $fleet_row['fleet_end_stay']
                 );
 
+                $this->Missions_Model->updateLostShipsAndDefensePoints($fleet_row['fleet_owner'], $lost_ships);
                 $this->Missions_Model->updateFleetArrayById([
                     'ships' => FleetsLib::setFleetShipsArray($new_ships),
                     'fleet_id' => $fleet_row['fleet_id'],
@@ -167,6 +170,7 @@ class Expedition extends Missions
                     $fleet_row['fleet_end_stay']
                 );
 
+                $this->Missions_Model->updateLostShipsAndDefensePoints($fleet_row['fleet_owner'], $current_fleet);
                 parent::removeFleet($fleet_row['fleet_id']);
             }
         }

--- a/src/upload/app/libraries/missions/Spy.php
+++ b/src/upload/app/libraries/missions/Spy.php
@@ -46,6 +46,8 @@ class Spy extends Missions
     {
         // do mission
         if (parent::canStartMission($fleet_row)) {
+            parent::makeUpdate($fleet_row['fleet_end_galaxy'], $fleet_row['fleet_end_system'], $fleet_row['fleet_end_planet'], $fleet_row['fleet_end_type']);
+
             $current_data = $this->Missions_Model->getSpyUserDataByCords([
                 'coords' => [
                     'galaxy' => $fleet_row['fleet_start_galaxy'],
@@ -67,8 +69,6 @@ class Spy extends Missions
             $CurrentSpyLvl = OfficiersLib::getMaxEspionage($current_data['research_espionage_technology'], $current_data['premium_officier_technocrat']);
             $TargetSpyLvl = OfficiersLib::getMaxEspionage($target_data['research_espionage_technology'], $target_data['premium_officier_technocrat']);
             $fleet = FleetsLib::getFleetShipsArray($fleet_row['fleet_array']);
-
-            parent::makeUpdate($fleet_row['fleet_end_galaxy'], $fleet_row['fleet_end_system'], $fleet_row['fleet_end_planet'], $fleet_row['fleet_end_type']);
 
             foreach ($fleet as $id => $amount) {
                 if ($id == "210") {

--- a/src/upload/app/models/libraries/missions/missions.php
+++ b/src/upload/app/models/libraries/missions/missions.php
@@ -13,12 +13,41 @@ namespace App\models\libraries\missions;
 
 use App\core\Model;
 use App\libraries\FleetsLib;
+use App\libraries\Statistics_library;
 
 /**
  * Missions Class
  */
 class Missions extends Model
 {
+    /**
+     * updateLostShipsAndDefensePoints
+     *
+     * @param integer $player_id   Player id
+     * @param array   $lost  Array of players lost units
+     *
+     * @return void
+     */
+    public function updateLostShipsAndDefensePoints($player_id, $lost)
+    {
+      $shippoints = 0;
+      $defensepoints = 0;
+      foreach ($lost as $unit => $lostcount) {
+        if ($unit >= 401) {
+          $defensepoints += Statistics_library::calculatePoints($unit, 1) * $lostcount;
+        }
+        else {
+          $shippoints += Statistics_library::calculatePoints($unit, 1) * $lostcount;
+        }
+      }
+      $this->db->query(
+          "UPDATE " . USERS_STATISTICS . " AS us SET
+          us.`user_statistic_ships_points` = us.`user_statistic_ships_points` - '" . $shippoints . "' ,
+          us.`user_statistic_defenses_points` = us.`user_statistic_defenses_points` - '" . $defensepoints . "'
+          WHERE us.`user_statistic_user_id` = '" . $player_id . "'"
+      );
+    }
+
     /**
      * Delete a fleet by its ID
      *

--- a/src/upload/app/models/libraries/missions/missions.php
+++ b/src/upload/app/models/libraries/missions/missions.php
@@ -433,7 +433,7 @@ class Missions extends Model
                             FROM " . PLANETS . " AS pc2
                             WHERE pc2.`planet_galaxy` = '" . $data['coords']['galaxy'] . "' AND
                                             pc2.`planet_system` = '" . $data['coords']['system'] . "' AND
-                                            pc2.`planet_planet` = '" . $data['coords']['planet'] . " AND
+                                            pc2.`planet_planet` = '" . $data['coords']['planet'] . "' AND
                                             pc2.`planet_type` = 1') AS galaxy_count,
                     (SELECT `research_astrophysics`
                             FROM " . RESEARCH . "


### PR DESCRIPTION
Previously espionage-probes returned obsolete data from the last activity the planet had instead of when the probe were there. 

The work-around was to send 2 probes right after another to first update the planet, and then get correct data.

This PR moves the planet update up to before the report is generated