### PR TITLE
fix german umlauts in mails

### DIFF
--- a/app/Libraries/Functions.php
+++ b/app/Libraries/Functions.php
@@ -300,6 +300,7 @@ abstract class Functions
                 $mail->Port = !empty(self::readConfig('mailing_smtp_port')) ? self::readConfig('mailing_smtp_port') : null;
                 $mail->SMTPSecure = !empty(self::readConfig('mailing_smtp_crypto')) ? self::readConfig('mailing_smtp_crypto') : null;
                 $mail->Timeout = !empty(self::readConfig('mailing_smtp_timeout')) ? self::readConfig('mailing_smtp_timeout') : null;
+                $mail->CharSet = "UTF-8";
 
                 if (
                     !empty(self::readConfig('mailing_smtp_user')) &&


### PR DESCRIPTION
this fixes the issue with wrong charset in mailer (for german umlauts) #516 