### PR TITLE
fix possible deprecated-error

### DIFF
--- a/app/Core/Database.php
+++ b/app/Core/Database.php
@@ -332,7 +332,7 @@ class Database
                     $return .= 'INSERT INTO ' . $table . ' VALUES(';
 
                     for ($j = 0; $j < $num_fields; $j++) {
-                        $row[$j] = addslashes($row[$j]);
+                        $row[$j] = addslashes((string)$row[$j]);
                         $row[$j] = str_replace("\n", "\\n", $row[$j]);
 
                         if (isset($row[$j])) {


### PR DESCRIPTION
the string from DB can be null, this is deprecated since php8.1 for addslashes(). To fix it, we cast the db-value to string.